### PR TITLE
PENG-3939: ignore changes to autoscaling tags

### DIFF
--- a/modules/compute/virtual_machine_scale_set/vmss_linux.tf
+++ b/modules/compute/virtual_machine_scale_set/vmss_linux.tf
@@ -244,11 +244,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
 
   health_probe_id = try(var.load_balancers[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.health_probe.loadbalancer_key].probes[each.value.health_probe.probe_key].id, null)
 
-  # lifecycle {
-  #   ignore_changes = [
-  #     resource_group_name, location
-  #   ]
-  # }
+  lifecycle {
+    ignore_changes = [
+      tags["__AzureDevOpsElasticPool"], tags["__AzureDevOpsElasticPoolTimeStamp"],
+    ]
+  }
 
 }
 


### PR DESCRIPTION
This change removes the following unnecessary changes from the terraform plan on `level3-devops-prod-deploy`:

 ```
~ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
        id                                                = "/subscriptions/8218f0df-d36a-4ba3-b9a3-3473136a9cd3/resourceGroups/rg-azdo-vmss-devops-prod-shared-001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss-azdo-share"
        name                                              = "vmss-azdo-share"
      ~ tags                                              = {
          - "__AzureDevOpsElasticPool"          = "vmss-azdo-share" -> null
          - "__AzureDevOpsElasticPoolTimeStamp" = "2/21/2024 3:16:07 PM" -> null
            "business_unit"                     = "shared"
            "caf_environment"                   = "prod"
            "caf_level"                         = "level3"
            "cost_center"                       = "1234"
            "criticality"                       = "high"
            "data_classification"               = "internal"
            "deployment_type"                   = "terraform"
            "dr"                                = "essential"
            "landingzone"                       = "devops_prod"
            "module"                            = "virtual_machine_scale_set"
            "ops_commitment"                    = "platform operations"
            "ops_team"                          = "cloud operations"
            "owner"                             = "cloudops@lv.com"
            "rover_version"                     = "aztfmod/rover:1.4.6-2305.1807"
            "service_class"                     = "gold"
        }
        # (25 unchanged attributes hidden)

        # (6 unchanged blocks hidden)
    }
```

